### PR TITLE
bugfix/remove refernces to /boot/efi

### DIFF
--- a/bootstrap/system-config.sh
+++ b/bootstrap/system-config.sh
@@ -91,9 +91,8 @@ tee -a /mnt/etc/nixos/${INST_CONFIG_FILE} <<-'EOF'
     grub.zfsSupport = true;
     # for systemd-autofs
     grub.extraPrepareConfig = ''
-      mkdir -p /boot/efis /boot/efi
+      mkdir -p /boot/efis
       for i in  /boot/efis/*; do mount $i ; done
-      mount /boot/efi
     '';
     grub.extraInstallCommands = ''
        export ESP_MIRROR=$(mktemp -d -p /tmp)

--- a/bootstrap/system-install.sh
+++ b/bootstrap/system-install.sh
@@ -42,7 +42,6 @@ zfs snapshot -r bpool_$INST_UUID/$INST_ID@install
 
 # Unmount EFI system partition
 umount /mnt/boot/efis/*
-umount /mnt/boot/efi
 
 # Export pools
 zpool export bpool_$INST_UUID


### PR DESCRIPTION
Removed references to /boot/efi after discussion with the openzfs docs author.